### PR TITLE
Make lexicon.py support to python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.6"
 env:
   # Boost
-  - BOOST_VERSION=default
+  - BOOST_VERSION=default CC=/usr/bin/gcc-5 CXX=/usr/bin/g++-5
 addons:
   apt:
     sources:
@@ -15,10 +15,7 @@ addons:
     - gcc-5
     - g++-5
     - libboost-all-dev
-sudo: required
-before_install:
-  - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
-  - gcc --version
+sudo: false
 install:
   - pip install Cython
   - pip install .

--- a/elit/component/template/lexicon.py
+++ b/elit/component/template/lexicon.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========================================================================
-from typing import Union
 
 import numpy as np
 from fasttext.model import WordVectorModel
@@ -26,11 +25,15 @@ __author__ = 'Jinho D. Choi'
 
 
 class NLPEmbedding:
-    def __init__(self, vsm: Union[KeyedVectors, WordVectorModel], key_field: str, emb_field: str):
+    def __init__(self, vsm, key_field, emb_field):
         """
         :param vsm: the vector space model in either the form of Word2Vec or FastText.
-        :param key_field: the field in NLPNode (e.g., word, pos) used as the key to retrieve the embedding from vsm.
+        :type vsm: Union[KeyedVectors, WordVectorModel]
+        :param key_field: the field in NLPNode (e.g., word, pos) used as the key to retrieve
+                the embedding from vsm.
+        :type key_field: str
         :param emb_field: where the embedding with respect to the key is saved in NLPNode.
+        :type emb_field: str
         """
         self.vsm = vsm
         self.key_field = key_field
@@ -38,25 +41,29 @@ class NLPEmbedding:
 
         if isinstance(vsm, KeyedVectors):
             vector_size = vsm.syn0.shape[1]
-
             # root
             np.random.seed(9)
             self.root = np.random.uniform(-.25, .25, (vector_size,)).astype('float32')
             np.random.seed()
-
             # zero
             self.zero = np.zeros((vector_size,)).astype('float32')
         elif isinstance(vsm, WordVectorModel):
             self.root = np.array(vsm[structure.ROOT_TAG]).astype('float32')
             self.zero = np.array(vsm['']).astype('float32')
 
-    def get(self, node: NLPNode) -> np.array:
+    def get(self, node):
         """
+        :param node:
+        :type node: NLPNode
         :return: the embedding of the specific node with respect to the key_field.
+        :rtype: np.array
         """
-        if node is None: return self.zero
-        if node.node_id == 0: return self.root
-        if hasattr(node, self.emb_field): return getattr(node, self.emb_field)
+        if node is None:
+            return self.zero
+        if node.node_id == 0:
+            return self.root
+        if hasattr(node, self.emb_field):
+            return getattr(node, self.emb_field)
 
         f = getattr(node, self.key_field)
         emb = None
@@ -72,10 +79,12 @@ class NLPEmbedding:
 
 
 class NLPLexiconMapper:
-    def __init__(self, w2v: KeyedVectors=None, f2v: WordVectorModel=None):
+    def __init__(self, w2v=None, f2v=None):
         """
         :param w2v: KeyedVectors.load_word2vec_format('*.bin').
+        :type KeyedVectors
         :param f2v: f2v.load_model('*.bin').
+        :type WordVectorModel
         """
-        self.w2v: NLPEmbedding = NLPEmbedding(w2v, 'word', 'w2v') if w2v else None
-        self.f2v: NLPEmbedding = NLPEmbedding(f2v, 'word', 'f2v') if f2v else None
+        self.w2v = NLPEmbedding(w2v, 'word', 'w2v') if w2v else None
+        self.f2v = NLPEmbedding(f2v, 'word', 'f2v') if f2v else None

--- a/setup.py
+++ b/setup.py
@@ -214,7 +214,7 @@ def setup_package():
         license='ALv2',
         packages=find_packages(exclude=EXCLUDE_FROM_PACKAGES),
         package_data={'': ['resources/tokenizer/*.txt',
-                           'resources/sample/*.tsv']},
+                           'resources/sample/*']},
         include_package_data=True,
         install_requires=[
             'nose',

--- a/tests/test_lexicon.py
+++ b/tests/test_lexicon.py
@@ -15,14 +15,26 @@
 # ========================================================================
 
 
-# from elit.component.template.lexicon import *
-#
-# __author__ = 'Jinho D. Choi'
-#
-# word_embeddings = KeyedVectors.load_word2vec_format('resources/sample/sample.w2v.bin', binary=True)
-# lexicon = NLPLexiconMapper(word_embeddings)
-#
-# print(get_default_vector(word_embeddings))
-# print(get_root_vector(word_embeddings))
-# print(get_vector(word_embeddings, 'Jinho'))
-# print(get_vector(word_embeddings, ''))
+from elit.component.template.lexicon import NLPLexiconMapper
+# from fasttext.model import WordVectorModel
+from gensim.models.keyedvectors import KeyedVectors
+
+import unittest
+import os
+
+__author__ = 'Jinho D. Choi'
+
+class LexiconTest(unittest.TestCase):
+
+    def setUp(self):
+        self.w2v_file = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                     './../elit/resources/sample/sample.w2v.bin')
+        self.word_embeddings = KeyedVectors.load_word2vec_format(self.w2v_file, binary=True)
+
+
+    def test_lexicon(self):
+        lexicon = NLPLexiconMapper(self.word_embeddings)
+        print(lexicon.w2v)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request is for making `elit/component/template/lexicon.py` support to python 3.4.

@jdchoi77 @tlee54 Would you help me or give me some hint that how to test lexicon? 

## Proposed Changes

  - Remove annotation
  - Remove deprecated tests
  - Structure unittest

## TODO

  - Test case of lexicon
  - Test case of word2vector
  - Test case of festtext